### PR TITLE
feat(finance): implement payment status APIs for entries and clubs

### DIFF
--- a/apps/backend/src/main/java/com/regattadesk/finance/ClubPaymentStatusDetails.java
+++ b/apps/backend/src/main/java/com/regattadesk/finance/ClubPaymentStatusDetails.java
@@ -1,0 +1,12 @@
+package com.regattadesk.finance;
+
+import java.util.UUID;
+
+public record ClubPaymentStatusDetails(
+    UUID regattaId,
+    UUID clubId,
+    PaymentStatus paymentStatus,
+    int billableEntryCount,
+    int paidEntryCount
+) {
+}

--- a/apps/backend/src/main/java/com/regattadesk/finance/ClubPaymentStatusUpdateRequestedEvent.java
+++ b/apps/backend/src/main/java/com/regattadesk/finance/ClubPaymentStatusUpdateRequestedEvent.java
@@ -1,0 +1,67 @@
+package com.regattadesk.finance;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.regattadesk.eventstore.DomainEvent;
+
+import java.util.UUID;
+
+public class ClubPaymentStatusUpdateRequestedEvent implements DomainEvent {
+    private final UUID clubId;
+    private final UUID regattaId;
+    private final String targetStatus;
+    private final int changedEntriesCount;
+    private final String requestedBy;
+    private final String paymentReference;
+
+    @JsonCreator
+    public ClubPaymentStatusUpdateRequestedEvent(
+        @JsonProperty("clubId") UUID clubId,
+        @JsonProperty("regattaId") UUID regattaId,
+        @JsonProperty("targetStatus") String targetStatus,
+        @JsonProperty("changedEntriesCount") int changedEntriesCount,
+        @JsonProperty("requestedBy") String requestedBy,
+        @JsonProperty("paymentReference") String paymentReference
+    ) {
+        this.clubId = clubId;
+        this.regattaId = regattaId;
+        this.targetStatus = targetStatus;
+        this.changedEntriesCount = changedEntriesCount;
+        this.requestedBy = requestedBy;
+        this.paymentReference = paymentReference;
+    }
+
+    @Override
+    public String getEventType() {
+        return "ClubPaymentStatusUpdateRequested";
+    }
+
+    @Override
+    public UUID getAggregateId() {
+        return clubId;
+    }
+
+    public UUID getClubId() {
+        return clubId;
+    }
+
+    public UUID getRegattaId() {
+        return regattaId;
+    }
+
+    public String getTargetStatus() {
+        return targetStatus;
+    }
+
+    public int getChangedEntriesCount() {
+        return changedEntriesCount;
+    }
+
+    public String getRequestedBy() {
+        return requestedBy;
+    }
+
+    public String getPaymentReference() {
+        return paymentReference;
+    }
+}

--- a/apps/backend/src/main/java/com/regattadesk/finance/EntryPaymentStatusDetails.java
+++ b/apps/backend/src/main/java/com/regattadesk/finance/EntryPaymentStatusDetails.java
@@ -1,0 +1,15 @@
+package com.regattadesk.finance;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record EntryPaymentStatusDetails(
+    UUID entryId,
+    UUID regattaId,
+    UUID billingClubId,
+    PaymentStatus paymentStatus,
+    Instant paidAt,
+    String paidBy,
+    String paymentReference
+) {
+}

--- a/apps/backend/src/main/java/com/regattadesk/finance/EntryPaymentStatusModel.java
+++ b/apps/backend/src/main/java/com/regattadesk/finance/EntryPaymentStatusModel.java
@@ -1,0 +1,117 @@
+package com.regattadesk.finance;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Domain model for entry payment status transitions.
+ */
+public class EntryPaymentStatusModel {
+    private PaymentStatus paymentStatus;
+    private Instant paidAt;
+    private String paidBy;
+    private String paymentReference;
+
+    public EntryPaymentStatusModel(
+        PaymentStatus paymentStatus,
+        Instant paidAt,
+        String paidBy,
+        String paymentReference
+    ) {
+        this.paymentStatus = Objects.requireNonNull(paymentStatus, "paymentStatus cannot be null");
+        this.paidAt = paidAt;
+        this.paidBy = paidBy;
+        this.paymentReference = paymentReference;
+    }
+
+    public TransitionResult transitionTo(
+        PaymentStatus targetStatus,
+        String nextPaymentReference,
+        String actor,
+        Instant now
+    ) {
+        Objects.requireNonNull(targetStatus, "targetStatus cannot be null");
+        Objects.requireNonNull(now, "now cannot be null");
+
+        String normalizedReference = normalizeBlank(nextPaymentReference);
+        String normalizedActor = normalizeBlank(actor);
+
+        if (targetStatus == paymentStatus
+            && Objects.equals(normalizedReference, paymentReference)) {
+            return TransitionResult.noChange();
+        }
+
+        PaymentStatus previousStatus = paymentStatus;
+        Instant previousPaidAt = paidAt;
+        String previousPaidBy = paidBy;
+        String previousPaymentReference = paymentReference;
+
+        this.paymentStatus = targetStatus;
+        this.paymentReference = normalizedReference;
+
+        if (targetStatus == PaymentStatus.PAID) {
+            this.paidAt = now;
+            this.paidBy = normalizedActor;
+        } else {
+            this.paidAt = null;
+            this.paidBy = null;
+        }
+
+        return TransitionResult.changed(
+            previousStatus,
+            previousPaidAt,
+            previousPaidBy,
+            previousPaymentReference,
+            this.paymentStatus,
+            this.paidAt,
+            this.paidBy,
+            this.paymentReference
+        );
+    }
+
+    private static String normalizeBlank(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value;
+    }
+
+    public record TransitionResult(
+        boolean changed,
+        PaymentStatus previousStatus,
+        Instant previousPaidAt,
+        String previousPaidBy,
+        String previousPaymentReference,
+        PaymentStatus nextStatus,
+        Instant nextPaidAt,
+        String nextPaidBy,
+        String nextPaymentReference
+    ) {
+        private static TransitionResult noChange() {
+            return new TransitionResult(false, null, null, null, null, null, null, null, null);
+        }
+
+        private static TransitionResult changed(
+            PaymentStatus previousStatus,
+            Instant previousPaidAt,
+            String previousPaidBy,
+            String previousPaymentReference,
+            PaymentStatus nextStatus,
+            Instant nextPaidAt,
+            String nextPaidBy,
+            String nextPaymentReference
+        ) {
+            return new TransitionResult(
+                true,
+                previousStatus,
+                previousPaidAt,
+                previousPaidBy,
+                previousPaymentReference,
+                nextStatus,
+                nextPaidAt,
+                nextPaidBy,
+                nextPaymentReference
+            );
+        }
+    }
+}

--- a/apps/backend/src/main/java/com/regattadesk/finance/EntryPaymentStatusUpdatedEvent.java
+++ b/apps/backend/src/main/java/com/regattadesk/finance/EntryPaymentStatusUpdatedEvent.java
@@ -1,0 +1,89 @@
+package com.regattadesk.finance;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.regattadesk.eventstore.DomainEvent;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class EntryPaymentStatusUpdatedEvent implements DomainEvent {
+    private final UUID entryId;
+    private final UUID regattaId;
+    private final UUID clubId;
+    private final String previousStatus;
+    private final String newStatus;
+    private final Instant paidAt;
+    private final String paidBy;
+    private final String paymentReference;
+    private final String reason;
+
+    @JsonCreator
+    public EntryPaymentStatusUpdatedEvent(
+        @JsonProperty("entryId") UUID entryId,
+        @JsonProperty("regattaId") UUID regattaId,
+        @JsonProperty("clubId") UUID clubId,
+        @JsonProperty("previousStatus") String previousStatus,
+        @JsonProperty("newStatus") String newStatus,
+        @JsonProperty("paidAt") Instant paidAt,
+        @JsonProperty("paidBy") String paidBy,
+        @JsonProperty("paymentReference") String paymentReference,
+        @JsonProperty("reason") String reason
+    ) {
+        this.entryId = entryId;
+        this.regattaId = regattaId;
+        this.clubId = clubId;
+        this.previousStatus = previousStatus;
+        this.newStatus = newStatus;
+        this.paidAt = paidAt;
+        this.paidBy = paidBy;
+        this.paymentReference = paymentReference;
+        this.reason = reason;
+    }
+
+    @Override
+    public String getEventType() {
+        return "EntryPaymentStatusUpdated";
+    }
+
+    @Override
+    public UUID getAggregateId() {
+        return entryId;
+    }
+
+    public UUID getEntryId() {
+        return entryId;
+    }
+
+    public UUID getRegattaId() {
+        return regattaId;
+    }
+
+    public UUID getClubId() {
+        return clubId;
+    }
+
+    public String getPreviousStatus() {
+        return previousStatus;
+    }
+
+    public String getNewStatus() {
+        return newStatus;
+    }
+
+    public Instant getPaidAt() {
+        return paidAt;
+    }
+
+    public String getPaidBy() {
+        return paidBy;
+    }
+
+    public String getPaymentReference() {
+        return paymentReference;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+}

--- a/apps/backend/src/main/java/com/regattadesk/finance/FinanceProjectionHandler.java
+++ b/apps/backend/src/main/java/com/regattadesk/finance/FinanceProjectionHandler.java
@@ -1,0 +1,176 @@
+package com.regattadesk.finance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.regattadesk.eventstore.EventEnvelope;
+import com.regattadesk.projection.ProjectionHandler;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+
+@ApplicationScoped
+public class FinanceProjectionHandler implements ProjectionHandler {
+
+    @Inject
+    DataSource dataSource;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Override
+    public String getProjectionName() {
+        return "finance_projection";
+    }
+
+    @Override
+    public boolean canHandle(EventEnvelope event) {
+        String eventType = event.getEventType();
+        return "EntryPaymentStatusUpdated".equals(eventType)
+            || "ClubPaymentStatusUpdateRequested".equals(eventType);
+    }
+
+    @Override
+    public void handle(EventEnvelope envelope) {
+        String eventType = envelope.getEventType();
+        try {
+            switch (eventType) {
+                case "EntryPaymentStatusUpdated" -> handleEntryPaymentStatusUpdated(envelope);
+                case "ClubPaymentStatusUpdateRequested" -> handleClubPaymentStatusUpdateRequested(envelope);
+                default -> Log.debugf("Ignoring finance event type: %s", eventType);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to handle finance event: " + eventType, e);
+        }
+    }
+
+    private void handleEntryPaymentStatusUpdated(EventEnvelope envelope) throws Exception {
+        EntryPaymentStatusUpdatedEvent event = parseEvent(envelope, EntryPaymentStatusUpdatedEvent.class);
+
+        try (Connection conn = dataSource.getConnection()) {
+            try (PreparedStatement stmt = conn.prepareStatement("""
+                UPDATE entries
+                SET payment_status = ?, paid_at = ?, paid_by = ?, payment_reference = ?, updated_at = ?
+                WHERE id = ? AND regatta_id = ?
+                """)) {
+                stmt.setString(1, event.getNewStatus());
+                stmt.setTimestamp(2, toTimestamp(event.getPaidAt()));
+                stmt.setString(3, event.getPaidBy());
+                stmt.setString(4, event.getPaymentReference());
+                stmt.setTimestamp(5, Timestamp.from(Instant.now()));
+                stmt.setObject(6, event.getEntryId());
+                stmt.setObject(7, event.getRegattaId());
+                stmt.executeUpdate();
+            }
+
+            if (event.getClubId() != null) {
+                recomputeClubPaymentStatus(conn, event.getRegattaId(), event.getClubId());
+            }
+        }
+    }
+
+    private void handleClubPaymentStatusUpdateRequested(EventEnvelope envelope) throws Exception {
+        ClubPaymentStatusUpdateRequestedEvent event = parseEvent(envelope, ClubPaymentStatusUpdateRequestedEvent.class);
+
+        try (Connection conn = dataSource.getConnection()) {
+            recomputeClubPaymentStatus(conn, event.getRegattaId(), event.getClubId());
+        }
+    }
+
+    void recomputeClubPaymentStatus(Connection conn, UUID regattaId, UUID clubId) throws Exception {
+        int billableCount = 0;
+        int paidCount = 0;
+
+        try (PreparedStatement stmt = conn.prepareStatement("""
+            SELECT
+                COUNT(*) AS billable_count,
+                COALESCE(SUM(CASE WHEN e.payment_status = 'paid' THEN 1 ELSE 0 END), 0) AS paid_count
+            FROM entries e
+            JOIN crews c ON c.id = e.crew_id
+            WHERE e.regatta_id = ?
+              AND (
+                    e.billing_club_id = ?
+                 OR (
+                        e.billing_club_id IS NULL
+                    AND c.is_composite = FALSE
+                    AND c.club_id = ?
+                 )
+              )
+            """)) {
+            stmt.setObject(1, regattaId);
+            stmt.setObject(2, clubId);
+            stmt.setObject(3, clubId);
+
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    billableCount = rs.getInt("billable_count");
+                    paidCount = rs.getInt("paid_count");
+                }
+            }
+        }
+
+        PaymentStatus derivedStatus = billableCount > 0 && paidCount == billableCount
+            ? PaymentStatus.PAID
+            : PaymentStatus.UNPAID;
+
+        String sql = upsertClubPaymentStatusSql(conn);
+        try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+            Timestamp now = Timestamp.from(Instant.now());
+            stmt.setObject(1, regattaId);
+            stmt.setObject(2, clubId);
+            stmt.setString(3, derivedStatus.value());
+            stmt.setInt(4, billableCount);
+            stmt.setInt(5, paidCount);
+            stmt.setTimestamp(6, now);
+            stmt.executeUpdate();
+        }
+    }
+
+    private String upsertClubPaymentStatusSql(Connection conn) throws Exception {
+        if (isPostgres(conn)) {
+            return """
+                INSERT INTO club_payment_statuses (regatta_id, club_id, payment_status, billable_entry_count, paid_entry_count, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT (regatta_id, club_id)
+                DO UPDATE SET
+                    payment_status = EXCLUDED.payment_status,
+                    billable_entry_count = EXCLUDED.billable_entry_count,
+                    paid_entry_count = EXCLUDED.paid_entry_count,
+                    updated_at = EXCLUDED.updated_at
+                """;
+        }
+
+        return """
+            MERGE INTO club_payment_statuses
+                (regatta_id, club_id, payment_status, billable_entry_count, paid_entry_count, updated_at)
+            KEY (regatta_id, club_id)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """;
+    }
+
+    private boolean isPostgres(Connection conn) throws Exception {
+        return "PostgreSQL".equalsIgnoreCase(conn.getMetaData().getDatabaseProductName());
+    }
+
+    private Timestamp toTimestamp(Instant value) {
+        return value == null ? null : Timestamp.from(value);
+    }
+
+    private <T> T parseEvent(EventEnvelope envelope, Class<T> eventClass) {
+        try {
+            String payload = envelope.getRawPayload();
+            if (payload != null && !payload.isBlank()) {
+                return objectMapper.readValue(payload, eventClass);
+            }
+            return objectMapper.convertValue(envelope.getPayload(), eventClass);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse finance event payload", e);
+        }
+    }
+}

--- a/apps/backend/src/main/java/com/regattadesk/finance/PaymentStatus.java
+++ b/apps/backend/src/main/java/com/regattadesk/finance/PaymentStatus.java
@@ -1,0 +1,33 @@
+package com.regattadesk.finance;
+
+import java.util.Locale;
+
+public enum PaymentStatus {
+    UNPAID("unpaid"),
+    PAID("paid");
+
+    private final String value;
+
+    PaymentStatus(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static PaymentStatus fromValue(String raw) {
+        if (raw == null || raw.isBlank()) {
+            throw new IllegalArgumentException("Payment status is required");
+        }
+
+        String normalized = raw.toLowerCase(Locale.ROOT);
+        for (PaymentStatus status : values()) {
+            if (status.value.equals(normalized)) {
+                return status;
+            }
+        }
+
+        throw new IllegalArgumentException("Payment status must be one of: unpaid, paid");
+    }
+}

--- a/apps/backend/src/main/java/com/regattadesk/finance/PaymentStatusService.java
+++ b/apps/backend/src/main/java/com/regattadesk/finance/PaymentStatusService.java
@@ -1,0 +1,368 @@
+package com.regattadesk.finance;
+
+import com.regattadesk.eventstore.DomainEvent;
+import com.regattadesk.eventstore.EventEnvelope;
+import com.regattadesk.eventstore.EventMetadata;
+import com.regattadesk.eventstore.EventStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@ApplicationScoped
+public class PaymentStatusService {
+
+    @Inject
+    EventStore eventStore;
+
+    @Inject
+    DataSource dataSource;
+
+    @Inject
+    FinanceProjectionHandler projectionHandler;
+
+    public Optional<EntryPaymentStatusDetails> getEntryPaymentStatus(UUID regattaId, UUID entryId) {
+        String sql = """
+            SELECT
+                e.id,
+                e.regatta_id,
+                e.billing_club_id,
+                e.payment_status,
+                e.paid_at,
+                e.paid_by,
+                e.payment_reference
+            FROM entries e
+            WHERE e.regatta_id = ? AND e.id = ?
+            """;
+
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setObject(1, regattaId);
+            stmt.setObject(2, entryId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (!rs.next()) {
+                    return Optional.empty();
+                }
+
+                return Optional.of(new EntryPaymentStatusDetails(
+                    (UUID) rs.getObject("id"),
+                    (UUID) rs.getObject("regatta_id"),
+                    (UUID) rs.getObject("billing_club_id"),
+                    PaymentStatus.fromValue(rs.getString("payment_status")),
+                    toInstant(rs.getTimestamp("paid_at")),
+                    rs.getString("paid_by"),
+                    rs.getString("payment_reference")
+                ));
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load entry payment status", e);
+        }
+    }
+
+    @Transactional
+    public EntryPaymentStatusDetails updateEntryPaymentStatus(
+        UUID regattaId,
+        UUID entryId,
+        PaymentStatus targetStatus,
+        String paymentReference,
+        String actor
+    ) {
+        EntryPaymentRow row = loadEntryPaymentRow(regattaId, entryId)
+            .orElseThrow(() -> new IllegalArgumentException("Entry not found"));
+
+        EntryPaymentStatusModel model = new EntryPaymentStatusModel(
+            row.paymentStatus(),
+            row.paidAt(),
+            row.paidBy(),
+            row.paymentReference()
+        );
+        EntryPaymentStatusModel.TransitionResult transition = model.transitionTo(
+            targetStatus,
+            paymentReference,
+            actor,
+            Instant.now()
+        );
+
+        if (transition.changed()) {
+            EntryPaymentStatusUpdatedEvent event = new EntryPaymentStatusUpdatedEvent(
+                entryId,
+                regattaId,
+                row.effectiveClubId(),
+                transition.previousStatus().value(),
+                transition.nextStatus().value(),
+                transition.nextPaidAt(),
+                transition.nextPaidBy(),
+                transition.nextPaymentReference(),
+                "single_entry_update"
+            );
+            appendAndProject(
+                entryId,
+                "EntryPayment",
+                List.of(event),
+                actor
+            );
+        }
+
+        return getEntryPaymentStatus(regattaId, entryId)
+            .orElseThrow(() -> new IllegalStateException("Entry disappeared during payment status update"));
+    }
+
+    public Optional<ClubPaymentStatusDetails> getClubPaymentStatus(UUID regattaId, UUID clubId) {
+        if (!clubExists(clubId)) {
+            return Optional.empty();
+        }
+
+        try (Connection conn = dataSource.getConnection()) {
+            projectionHandler.recomputeClubPaymentStatus(conn, regattaId, clubId);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to refresh club payment status projection", e);
+        }
+
+        String sql = """
+            SELECT regatta_id, club_id, payment_status, billable_entry_count, paid_entry_count
+            FROM club_payment_statuses
+            WHERE regatta_id = ? AND club_id = ?
+            """;
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setObject(1, regattaId);
+            stmt.setObject(2, clubId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (!rs.next()) {
+                    return Optional.of(new ClubPaymentStatusDetails(
+                        regattaId,
+                        clubId,
+                        PaymentStatus.UNPAID,
+                        0,
+                        0
+                    ));
+                }
+
+                return Optional.of(new ClubPaymentStatusDetails(
+                    (UUID) rs.getObject("regatta_id"),
+                    (UUID) rs.getObject("club_id"),
+                    PaymentStatus.fromValue(rs.getString("payment_status")),
+                    rs.getInt("billable_entry_count"),
+                    rs.getInt("paid_entry_count")
+                ));
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load club payment status", e);
+        }
+    }
+
+    @Transactional
+    public ClubPaymentStatusDetails updateClubPaymentStatus(
+        UUID regattaId,
+        UUID clubId,
+        PaymentStatus targetStatus,
+        String paymentReference,
+        String actor
+    ) {
+        if (!clubExists(clubId)) {
+            throw new IllegalArgumentException("Club not found");
+        }
+
+        List<EntryPaymentRow> rows = listClubEntryPaymentRows(regattaId, clubId);
+        int changedCount = 0;
+        for (EntryPaymentRow row : rows) {
+            EntryPaymentStatusModel model = new EntryPaymentStatusModel(
+                row.paymentStatus(),
+                row.paidAt(),
+                row.paidBy(),
+                row.paymentReference()
+            );
+            EntryPaymentStatusModel.TransitionResult transition = model.transitionTo(
+                targetStatus,
+                paymentReference,
+                actor,
+                Instant.now()
+            );
+            if (!transition.changed()) {
+                continue;
+            }
+
+            changedCount++;
+            EntryPaymentStatusUpdatedEvent entryEvent = new EntryPaymentStatusUpdatedEvent(
+                row.entryId(),
+                regattaId,
+                row.effectiveClubId(),
+                transition.previousStatus().value(),
+                transition.nextStatus().value(),
+                transition.nextPaidAt(),
+                transition.nextPaidBy(),
+                transition.nextPaymentReference(),
+                "club_update"
+            );
+            appendAndProject(row.entryId(), "EntryPayment", List.of(entryEvent), actor);
+        }
+
+        ClubPaymentStatusUpdateRequestedEvent clubEvent = new ClubPaymentStatusUpdateRequestedEvent(
+            clubId,
+            regattaId,
+            targetStatus.value(),
+            changedCount,
+            actor,
+            paymentReference
+        );
+        appendAndProject(clubId, "ClubPayment", List.of(clubEvent), actor);
+
+        return getClubPaymentStatus(regattaId, clubId)
+            .orElseThrow(() -> new IllegalStateException("Club disappeared during payment status update"));
+    }
+
+    private Optional<EntryPaymentRow> loadEntryPaymentRow(UUID regattaId, UUID entryId) {
+        String sql = """
+            SELECT
+                e.id,
+                e.regatta_id,
+                e.billing_club_id,
+                e.payment_status,
+                e.paid_at,
+                e.paid_by,
+                e.payment_reference,
+                c.id AS crew_id,
+                c.club_id AS crew_club_id,
+                c.is_composite
+            FROM entries e
+            JOIN crews c ON c.id = e.crew_id
+            WHERE e.regatta_id = ? AND e.id = ?
+            """;
+
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setObject(1, regattaId);
+            stmt.setObject(2, entryId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (!rs.next()) {
+                    return Optional.empty();
+                }
+                return Optional.of(mapEntryPaymentRow(rs));
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load entry payment row", e);
+        }
+    }
+
+    private List<EntryPaymentRow> listClubEntryPaymentRows(UUID regattaId, UUID clubId) {
+        List<EntryPaymentRow> rows = new ArrayList<>();
+        String sql = """
+            SELECT
+                e.id,
+                e.regatta_id,
+                e.billing_club_id,
+                e.payment_status,
+                e.paid_at,
+                e.paid_by,
+                e.payment_reference,
+                c.id AS crew_id,
+                c.club_id AS crew_club_id,
+                c.is_composite
+            FROM entries e
+            JOIN crews c ON c.id = e.crew_id
+            WHERE e.regatta_id = ?
+              AND (
+                    e.billing_club_id = ?
+                 OR (
+                        e.billing_club_id IS NULL
+                    AND c.is_composite = FALSE
+                    AND c.club_id = ?
+                 )
+              )
+            """;
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setObject(1, regattaId);
+            stmt.setObject(2, clubId);
+            stmt.setObject(3, clubId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    rows.add(mapEntryPaymentRow(rs));
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to list club entry payments", e);
+        }
+        return rows;
+    }
+
+    private EntryPaymentRow mapEntryPaymentRow(ResultSet rs) throws Exception {
+        UUID billingClubId = (UUID) rs.getObject("billing_club_id");
+        UUID crewClubId = (UUID) rs.getObject("crew_club_id");
+        boolean isComposite = rs.getBoolean("is_composite");
+
+        UUID effectiveClubId = billingClubId != null
+            ? billingClubId
+            : (!isComposite ? crewClubId : null);
+
+        return new EntryPaymentRow(
+            (UUID) rs.getObject("id"),
+            (UUID) rs.getObject("regatta_id"),
+            PaymentStatus.fromValue(rs.getString("payment_status")),
+            toInstant(rs.getTimestamp("paid_at")),
+            rs.getString("paid_by"),
+            rs.getString("payment_reference"),
+            effectiveClubId
+        );
+    }
+
+    private void appendAndProject(
+        UUID aggregateId,
+        String aggregateType,
+        List<? extends DomainEvent> events,
+        String actor
+    ) {
+        long expectedVersion = eventStore.getCurrentVersion(aggregateId);
+        long fromSequence = expectedVersion + 1;
+        EventMetadata metadata = EventMetadata.builder()
+            .correlationId(UUID.randomUUID())
+            .addData("actor", actor)
+            .build();
+
+        eventStore.append(aggregateId, aggregateType, expectedVersion, List.copyOf(events), metadata);
+
+        for (EventEnvelope envelope : eventStore.readStream(aggregateId, fromSequence)) {
+            if (projectionHandler.canHandle(envelope)) {
+                projectionHandler.handle(envelope);
+            }
+        }
+    }
+
+    private Instant toInstant(Timestamp timestamp) {
+        return timestamp == null ? null : timestamp.toInstant();
+    }
+
+    private boolean clubExists(UUID clubId) {
+        String sql = "SELECT id FROM clubs WHERE id = ?";
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setObject(1, clubId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                return rs.next();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to verify club existence", e);
+        }
+    }
+
+    private record EntryPaymentRow(
+        UUID entryId,
+        UUID regattaId,
+        PaymentStatus paymentStatus,
+        Instant paidAt,
+        String paidBy,
+        String paymentReference,
+        UUID effectiveClubId
+    ) {
+    }
+}

--- a/apps/backend/src/main/java/com/regattadesk/finance/api/ClubPaymentStatusResponse.java
+++ b/apps/backend/src/main/java/com/regattadesk/finance/api/ClubPaymentStatusResponse.java
@@ -1,0 +1,29 @@
+package com.regattadesk.finance.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.regattadesk.finance.ClubPaymentStatusDetails;
+
+import java.util.UUID;
+
+public record ClubPaymentStatusResponse(
+    @JsonProperty("regatta_id")
+    UUID regattaId,
+    @JsonProperty("club_id")
+    UUID clubId,
+    @JsonProperty("payment_status")
+    String paymentStatus,
+    @JsonProperty("billable_entry_count")
+    int billableEntryCount,
+    @JsonProperty("paid_entry_count")
+    int paidEntryCount
+) {
+    public static ClubPaymentStatusResponse from(ClubPaymentStatusDetails details) {
+        return new ClubPaymentStatusResponse(
+            details.regattaId(),
+            details.clubId(),
+            details.paymentStatus().value(),
+            details.billableEntryCount(),
+            details.paidEntryCount()
+        );
+    }
+}

--- a/apps/backend/src/main/java/com/regattadesk/finance/api/EntryPaymentStatusResponse.java
+++ b/apps/backend/src/main/java/com/regattadesk/finance/api/EntryPaymentStatusResponse.java
@@ -1,0 +1,33 @@
+package com.regattadesk.finance.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.regattadesk.finance.EntryPaymentStatusDetails;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record EntryPaymentStatusResponse(
+    @JsonProperty("entry_id")
+    UUID entryId,
+    @JsonProperty("billing_club_id")
+    UUID billingClubId,
+    @JsonProperty("payment_status")
+    String paymentStatus,
+    @JsonProperty("paid_at")
+    Instant paidAt,
+    @JsonProperty("paid_by")
+    String paidBy,
+    @JsonProperty("payment_reference")
+    String paymentReference
+) {
+    public static EntryPaymentStatusResponse from(EntryPaymentStatusDetails details) {
+        return new EntryPaymentStatusResponse(
+            details.entryId(),
+            details.billingClubId(),
+            details.paymentStatus().value(),
+            details.paidAt(),
+            details.paidBy(),
+            details.paymentReference()
+        );
+    }
+}

--- a/apps/backend/src/main/java/com/regattadesk/finance/api/PaymentStatusResource.java
+++ b/apps/backend/src/main/java/com/regattadesk/finance/api/PaymentStatusResource.java
@@ -1,0 +1,154 @@
+package com.regattadesk.finance.api;
+
+import com.regattadesk.api.dto.ErrorResponse;
+import com.regattadesk.finance.PaymentStatus;
+import com.regattadesk.finance.PaymentStatusService;
+import com.regattadesk.security.RequireRole;
+import com.regattadesk.security.SecurityContext;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.UUID;
+
+import static com.regattadesk.security.Role.FINANCIAL_MANAGER;
+import static com.regattadesk.security.Role.HEAD_OF_JURY;
+import static com.regattadesk.security.Role.INFO_DESK;
+import static com.regattadesk.security.Role.REGATTA_ADMIN;
+import static com.regattadesk.security.Role.SUPER_ADMIN;
+
+@Path("/api/v1/regattas/{regatta_id}")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class PaymentStatusResource {
+
+    @Inject
+    PaymentStatusService paymentStatusService;
+
+    @Inject
+    SecurityContext securityContext;
+
+    @GET
+    @Path("/entries/{entry_id}/payment_status")
+    @RequireRole({SUPER_ADMIN, REGATTA_ADMIN, HEAD_OF_JURY, INFO_DESK, FINANCIAL_MANAGER})
+    public Response getEntryPaymentStatus(
+        @PathParam("regatta_id") UUID regattaId,
+        @PathParam("entry_id") UUID entryId
+    ) {
+        try {
+            return paymentStatusService.getEntryPaymentStatus(regattaId, entryId)
+                .map(EntryPaymentStatusResponse::from)
+                .map(payload -> Response.ok(payload).build())
+                .orElseGet(() -> Response.status(Response.Status.NOT_FOUND)
+                    .entity(ErrorResponse.notFound("Entry not found"))
+                    .build());
+        } catch (Exception e) {
+            return Response.serverError()
+                .entity(ErrorResponse.internalError("Failed to get entry payment status"))
+                .build();
+        }
+    }
+
+    @PUT
+    @Path("/entries/{entry_id}/payment_status")
+    @RequireRole({SUPER_ADMIN, REGATTA_ADMIN, FINANCIAL_MANAGER})
+    public Response updateEntryPaymentStatus(
+        @PathParam("regatta_id") UUID regattaId,
+        @PathParam("entry_id") UUID entryId,
+        PaymentStatusUpdateRequest request
+    ) {
+        try {
+            PaymentStatus targetStatus = PaymentStatus.fromValue(request.paymentStatus());
+            String actor = securityContext.getPrincipal() != null
+                ? securityContext.getPrincipal().getUsername()
+                : "unknown";
+
+            var updated = paymentStatusService.updateEntryPaymentStatus(
+                regattaId,
+                entryId,
+                targetStatus,
+                request.paymentReference(),
+                actor
+            );
+            return Response.ok(EntryPaymentStatusResponse.from(updated)).build();
+        } catch (IllegalArgumentException e) {
+            if ("Entry not found".equals(e.getMessage())) {
+                return Response.status(Response.Status.NOT_FOUND)
+                    .entity(ErrorResponse.notFound(e.getMessage()))
+                    .build();
+            }
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(ErrorResponse.badRequest(e.getMessage()))
+                .build();
+        } catch (Exception e) {
+            return Response.serverError()
+                .entity(ErrorResponse.internalError("Failed to update entry payment status"))
+                .build();
+        }
+    }
+
+    @GET
+    @Path("/clubs/{club_id}/payment_status")
+    @RequireRole({SUPER_ADMIN, REGATTA_ADMIN, HEAD_OF_JURY, INFO_DESK, FINANCIAL_MANAGER})
+    public Response getClubPaymentStatus(
+        @PathParam("regatta_id") UUID regattaId,
+        @PathParam("club_id") UUID clubId
+    ) {
+        try {
+            return paymentStatusService.getClubPaymentStatus(regattaId, clubId)
+                .map(ClubPaymentStatusResponse::from)
+                .map(payload -> Response.ok(payload).build())
+                .orElseGet(() -> Response.status(Response.Status.NOT_FOUND)
+                    .entity(ErrorResponse.notFound("Club not found"))
+                    .build());
+        } catch (Exception e) {
+            return Response.serverError()
+                .entity(ErrorResponse.internalError("Failed to get club payment status"))
+                .build();
+        }
+    }
+
+    @PUT
+    @Path("/clubs/{club_id}/payment_status")
+    @RequireRole({SUPER_ADMIN, REGATTA_ADMIN, FINANCIAL_MANAGER})
+    public Response updateClubPaymentStatus(
+        @PathParam("regatta_id") UUID regattaId,
+        @PathParam("club_id") UUID clubId,
+        PaymentStatusUpdateRequest request
+    ) {
+        try {
+            PaymentStatus targetStatus = PaymentStatus.fromValue(request.paymentStatus());
+            String actor = securityContext.getPrincipal() != null
+                ? securityContext.getPrincipal().getUsername()
+                : "unknown";
+
+            var updated = paymentStatusService.updateClubPaymentStatus(
+                regattaId,
+                clubId,
+                targetStatus,
+                request.paymentReference(),
+                actor
+            );
+            return Response.ok(ClubPaymentStatusResponse.from(updated)).build();
+        } catch (IllegalArgumentException e) {
+            if ("Club not found".equals(e.getMessage())) {
+                return Response.status(Response.Status.NOT_FOUND)
+                    .entity(ErrorResponse.notFound(e.getMessage()))
+                    .build();
+            }
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(ErrorResponse.badRequest(e.getMessage()))
+                .build();
+        } catch (Exception e) {
+            return Response.serverError()
+                .entity(ErrorResponse.internalError("Failed to update club payment status"))
+                .build();
+        }
+    }
+}

--- a/apps/backend/src/main/java/com/regattadesk/finance/api/PaymentStatusUpdateRequest.java
+++ b/apps/backend/src/main/java/com/regattadesk/finance/api/PaymentStatusUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.regattadesk.finance.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record PaymentStatusUpdateRequest(
+    @JsonProperty("payment_status")
+    String paymentStatus,
+    @JsonProperty("payment_reference")
+    String paymentReference
+) {
+}

--- a/apps/backend/src/main/resources/db/migration/V009__club_payment_status_projection.sql
+++ b/apps/backend/src/main/resources/db/migration/V009__club_payment_status_projection.sql
@@ -1,0 +1,19 @@
+-- Finance read model for BC08-001
+-- Derived club payment status projection table
+
+CREATE TABLE club_payment_statuses (
+    regatta_id UUID NOT NULL REFERENCES regattas(id) ON DELETE CASCADE,
+    club_id UUID NOT NULL REFERENCES clubs(id) ON DELETE CASCADE,
+    payment_status VARCHAR(50) NOT NULL DEFAULT 'unpaid',
+    billable_entry_count INTEGER NOT NULL DEFAULT 0,
+    paid_entry_count INTEGER NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (regatta_id, club_id),
+    CHECK (payment_status IN ('unpaid', 'paid')),
+    CHECK (billable_entry_count >= 0),
+    CHECK (paid_entry_count >= 0),
+    CHECK (paid_entry_count <= billable_entry_count)
+);
+
+CREATE INDEX idx_club_payment_statuses_status
+    ON club_payment_statuses(payment_status);

--- a/apps/backend/src/main/resources/db/migration/h2/V009__club_payment_status_projection.sql
+++ b/apps/backend/src/main/resources/db/migration/h2/V009__club_payment_status_projection.sql
@@ -1,0 +1,19 @@
+-- Finance read model for BC08-001 (H2 compatible)
+-- Derived club payment status projection table
+
+CREATE TABLE club_payment_statuses (
+    regatta_id UUID NOT NULL REFERENCES regattas(id) ON DELETE CASCADE,
+    club_id UUID NOT NULL REFERENCES clubs(id) ON DELETE CASCADE,
+    payment_status CHARACTER VARYING(50) NOT NULL DEFAULT 'unpaid',
+    billable_entry_count INTEGER NOT NULL DEFAULT 0,
+    paid_entry_count INTEGER NOT NULL DEFAULT 0,
+    updated_at TIMESTAMP NOT NULL DEFAULT now(),
+    PRIMARY KEY (regatta_id, club_id),
+    CONSTRAINT chk_club_payment_status_value CHECK (payment_status IN ('unpaid', 'paid')),
+    CONSTRAINT chk_club_payment_billable_count CHECK (billable_entry_count >= 0),
+    CONSTRAINT chk_club_payment_paid_count CHECK (paid_entry_count >= 0),
+    CONSTRAINT chk_club_payment_paid_lte_billable CHECK (paid_entry_count <= billable_entry_count)
+);
+
+CREATE INDEX IF NOT EXISTS idx_club_payment_statuses_status
+    ON club_payment_statuses(payment_status);

--- a/apps/backend/src/test/java/com/regattadesk/finance/EntryPaymentStatusModelTest.java
+++ b/apps/backend/src/test/java/com/regattadesk/finance/EntryPaymentStatusModelTest.java
@@ -1,0 +1,87 @@
+package com.regattadesk.finance;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EntryPaymentStatusModelTest {
+
+    @Test
+    void transitionUnpaidToPaid_setsAuditMetadata() {
+        EntryPaymentStatusModel model = new EntryPaymentStatusModel(
+            PaymentStatus.UNPAID,
+            null,
+            null,
+            null
+        );
+
+        Instant now = Instant.parse("2026-02-22T10:15:30Z");
+        var result = model.transitionTo(PaymentStatus.PAID, "INV-2026-001", "finance-user", now);
+
+        assertTrue(result.changed());
+        assertEquals(PaymentStatus.UNPAID, result.previousStatus());
+        assertEquals(PaymentStatus.PAID, result.nextStatus());
+        assertEquals("INV-2026-001", result.nextPaymentReference());
+        assertEquals("finance-user", result.nextPaidBy());
+        assertEquals(now, result.nextPaidAt());
+    }
+
+    @Test
+    void transitionPaidToUnpaid_clearsPaidMetadata() {
+        EntryPaymentStatusModel model = new EntryPaymentStatusModel(
+            PaymentStatus.PAID,
+            Instant.parse("2026-02-20T09:00:00Z"),
+            "finance-user",
+            "INV-2026-001"
+        );
+
+        var result = model.transitionTo(PaymentStatus.UNPAID, null, "finance-user", Instant.now());
+
+        assertTrue(result.changed());
+        assertEquals(PaymentStatus.PAID, result.previousStatus());
+        assertEquals(PaymentStatus.UNPAID, result.nextStatus());
+        assertNull(result.nextPaidAt());
+        assertNull(result.nextPaidBy());
+        assertNull(result.nextPaymentReference());
+    }
+
+    @Test
+    void transitionSameStatusAndReference_isNoOp() {
+        EntryPaymentStatusModel model = new EntryPaymentStatusModel(
+            PaymentStatus.UNPAID,
+            null,
+            null,
+            null
+        );
+
+        var result = model.transitionTo(PaymentStatus.UNPAID, null, "finance-user", Instant.now());
+
+        assertFalse(result.changed());
+        assertNull(result.nextStatus());
+        assertNull(result.previousStatus());
+    }
+
+    @Test
+    void transitionSameStatusDifferentReference_isChange() {
+        EntryPaymentStatusModel model = new EntryPaymentStatusModel(
+            PaymentStatus.PAID,
+            Instant.parse("2026-02-20T09:00:00Z"),
+            "finance-user",
+            "REF-OLD"
+        );
+
+        var result = model.transitionTo(PaymentStatus.PAID, "REF-NEW", "finance-user", Instant.now());
+
+        assertTrue(result.changed());
+        assertEquals(PaymentStatus.PAID, result.previousStatus());
+        assertEquals(PaymentStatus.PAID, result.nextStatus());
+        assertEquals("REF-NEW", result.nextPaymentReference());
+        assertNotNull(result.nextPaidAt());
+    }
+}

--- a/apps/backend/src/test/java/com/regattadesk/finance/PaymentStatusResourceIT.java
+++ b/apps/backend/src/test/java/com/regattadesk/finance/PaymentStatusResourceIT.java
@@ -1,0 +1,299 @@
+package com.regattadesk.finance;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+class PaymentStatusResourceIT {
+
+    @Inject
+    DataSource dataSource;
+
+    @Test
+    void entryPaymentStatus_canBeUpdatedAndIsAuditable() throws Exception {
+        TestData data = seedFinanceData();
+
+        given()
+            .header("Remote-User", "fin-user")
+            .header("Remote-Groups", "financial_manager")
+            .when()
+            .get("/api/v1/regattas/" + data.regattaId + "/entries/" + data.entryOneId + "/payment_status")
+            .then()
+            .statusCode(200)
+            .body("payment_status", equalTo("unpaid"));
+
+        given()
+            .header("Remote-User", "fin-user")
+            .header("Remote-Groups", "financial_manager")
+            .contentType("application/json")
+            .body("""
+                {
+                  "payment_status": "paid",
+                  "payment_reference": "BANK-REF-123"
+                }
+                """)
+            .when()
+            .put("/api/v1/regattas/" + data.regattaId + "/entries/" + data.entryOneId + "/payment_status")
+            .then()
+            .statusCode(200)
+            .body("payment_status", equalTo("paid"))
+            .body("payment_reference", equalTo("BANK-REF-123"))
+            .body("paid_by", equalTo("fin-user"));
+
+        assertEquals(1, countAuditEvents("EntryPaymentStatusUpdated", data.entryOneId));
+    }
+
+    @Test
+    void clubPaymentStatus_updateSetsAllBillableEntries() throws Exception {
+        TestData data = seedFinanceData();
+
+        given()
+            .header("Remote-User", "fin-user")
+            .header("Remote-Groups", "financial_manager")
+            .contentType("application/json")
+            .body("""
+                {
+                  "payment_status": "paid",
+                  "payment_reference": "CLUB-BULK-001"
+                }
+                """)
+            .when()
+            .put("/api/v1/regattas/" + data.regattaId + "/clubs/" + data.clubId + "/payment_status")
+            .then()
+            .statusCode(200)
+            .body("club_id", equalTo(data.clubId.toString()))
+            .body("payment_status", equalTo("paid"))
+            .body("billable_entry_count", equalTo(2))
+            .body("paid_entry_count", equalTo(2));
+
+        assertEquals(1, countAuditEvents("ClubPaymentStatusUpdateRequested", data.clubId));
+        assertEquals(2, countAuditEvents("EntryPaymentStatusUpdated", data.entryOneId) +
+            countAuditEvents("EntryPaymentStatusUpdated", data.entryTwoId));
+    }
+
+    @Test
+    void unauthorizedRoles_cannotMutatePaymentStatus() throws Exception {
+        TestData data = seedFinanceData();
+
+        given()
+            .header("Remote-User", "desk-user")
+            .header("Remote-Groups", "info_desk")
+            .contentType("application/json")
+            .body("""
+                {
+                  "payment_status": "paid"
+                }
+                """)
+            .when()
+            .put("/api/v1/regattas/" + data.regattaId + "/entries/" + data.entryOneId + "/payment_status")
+            .then()
+            .statusCode(403);
+
+        given()
+            .header("Remote-User", "desk-user")
+            .header("Remote-Groups", "info_desk")
+            .contentType("application/json")
+            .body("""
+                {
+                  "payment_status": "paid"
+                }
+                """)
+            .when()
+            .put("/api/v1/regattas/" + data.regattaId + "/clubs/" + data.clubId + "/payment_status")
+            .then()
+            .statusCode(403);
+    }
+
+    private int countAuditEvents(String eventType, UUID aggregateId) throws Exception {
+        String sql = """
+            SELECT COUNT(*) AS c
+            FROM event_store
+            WHERE event_type = ? AND aggregate_id = ?
+            """;
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, eventType);
+            stmt.setObject(2, aggregateId);
+            try (var rs = stmt.executeQuery()) {
+                rs.next();
+                return rs.getInt("c");
+            }
+        }
+    }
+
+    private TestData seedFinanceData() throws Exception {
+        UUID regattaId = UUID.randomUUID();
+        UUID clubId = UUID.randomUUID();
+        UUID categoryId = UUID.randomUUID();
+        UUID boatTypeId = UUID.randomUUID();
+        UUID blockId = UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+        UUID crewOneId = UUID.randomUUID();
+        UUID crewTwoId = UUID.randomUUID();
+        UUID entryOneId = UUID.randomUUID();
+        UUID entryTwoId = UUID.randomUUID();
+
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(false);
+
+            try (PreparedStatement stmt = conn.prepareStatement("""
+                INSERT INTO regattas (id, name, time_zone, status, entry_fee, currency, draw_revision, results_revision, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, 0, 0, ?, ?)
+                """)) {
+                Timestamp now = Timestamp.from(Instant.now());
+                stmt.setObject(1, regattaId);
+                stmt.setString(2, "Finance IT Regatta");
+                stmt.setString(3, "Europe/Amsterdam");
+                stmt.setString(4, "draft");
+                stmt.setBigDecimal(5, BigDecimal.valueOf(12.50));
+                stmt.setString(6, "EUR");
+                stmt.setTimestamp(7, now);
+                stmt.setTimestamp(8, now);
+                stmt.executeUpdate();
+            }
+
+            try (PreparedStatement stmt = conn.prepareStatement("""
+                INSERT INTO clubs (id, name, short_name, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                """)) {
+                Timestamp now = Timestamp.from(Instant.now());
+                stmt.setObject(1, clubId);
+                stmt.setString(2, "Finance Club");
+                stmt.setString(3, "FC");
+                stmt.setTimestamp(4, now);
+                stmt.setTimestamp(5, now);
+                stmt.executeUpdate();
+            }
+
+            try (PreparedStatement stmt = conn.prepareStatement("""
+                INSERT INTO categories (id, name, gender, is_global, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """)) {
+                Timestamp now = Timestamp.from(Instant.now());
+                stmt.setObject(1, categoryId);
+                stmt.setString(2, "Senior");
+                stmt.setString(3, "ANY");
+                stmt.setBoolean(4, true);
+                stmt.setTimestamp(5, now);
+                stmt.setTimestamp(6, now);
+                stmt.executeUpdate();
+            }
+
+            try (PreparedStatement stmt = conn.prepareStatement("""
+                INSERT INTO boat_types (id, code, name, rowers, coxswain, sculling, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """)) {
+                Timestamp now = Timestamp.from(Instant.now());
+                stmt.setObject(1, boatTypeId);
+                stmt.setString(2, "IT" + UUID.randomUUID().toString().substring(0, 6));
+                stmt.setString(3, "IT Boat");
+                stmt.setInt(4, 1);
+                stmt.setBoolean(5, false);
+                stmt.setBoolean(6, true);
+                stmt.setTimestamp(7, now);
+                stmt.setTimestamp(8, now);
+                stmt.executeUpdate();
+            }
+
+            try (PreparedStatement stmt = conn.prepareStatement("""
+                INSERT INTO blocks (id, regatta_id, name, start_time, event_interval_seconds, crew_interval_seconds, display_order, created_at, updated_at)
+                VALUES (?, ?, ?, ?, 300, 60, 0, ?, ?)
+                """)) {
+                Timestamp now = Timestamp.from(Instant.now());
+                stmt.setObject(1, blockId);
+                stmt.setObject(2, regattaId);
+                stmt.setString(3, "Block 1");
+                stmt.setTimestamp(4, now);
+                stmt.setTimestamp(5, now);
+                stmt.setTimestamp(6, now);
+                stmt.executeUpdate();
+            }
+
+            try (PreparedStatement stmt = conn.prepareStatement("""
+                INSERT INTO events (id, regatta_id, category_id, boat_type_id, name, display_order, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, 0, ?, ?)
+                """)) {
+                Timestamp now = Timestamp.from(Instant.now());
+                stmt.setObject(1, eventId);
+                stmt.setObject(2, regattaId);
+                stmt.setObject(3, categoryId);
+                stmt.setObject(4, boatTypeId);
+                stmt.setString(5, "Event 1");
+                stmt.setTimestamp(6, now);
+                stmt.setTimestamp(7, now);
+                stmt.executeUpdate();
+            }
+
+            try (PreparedStatement stmt = conn.prepareStatement("""
+                INSERT INTO crews (id, display_name, is_composite, club_id, created_at, updated_at)
+                VALUES (?, ?, FALSE, ?, ?, ?)
+                """)) {
+                Timestamp now = Timestamp.from(Instant.now());
+                stmt.setObject(1, crewOneId);
+                stmt.setString(2, "Crew One");
+                stmt.setObject(3, clubId);
+                stmt.setTimestamp(4, now);
+                stmt.setTimestamp(5, now);
+                stmt.executeUpdate();
+
+                stmt.setObject(1, crewTwoId);
+                stmt.setString(2, "Crew Two");
+                stmt.setObject(3, clubId);
+                stmt.setTimestamp(4, now);
+                stmt.setTimestamp(5, now);
+                stmt.executeUpdate();
+            }
+
+            try (PreparedStatement stmt = conn.prepareStatement("""
+                INSERT INTO entries (id, regatta_id, event_id, block_id, crew_id, billing_club_id, status, payment_status, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, 'entered', 'unpaid', ?, ?)
+                """)) {
+                Timestamp now = Timestamp.from(Instant.now());
+                stmt.setObject(1, entryOneId);
+                stmt.setObject(2, regattaId);
+                stmt.setObject(3, eventId);
+                stmt.setObject(4, blockId);
+                stmt.setObject(5, crewOneId);
+                stmt.setObject(6, clubId);
+                stmt.setTimestamp(7, now);
+                stmt.setTimestamp(8, now);
+                stmt.executeUpdate();
+
+                stmt.setObject(1, entryTwoId);
+                stmt.setObject(2, regattaId);
+                stmt.setObject(3, eventId);
+                stmt.setObject(4, blockId);
+                stmt.setObject(5, crewTwoId);
+                stmt.setObject(6, clubId);
+                stmt.setTimestamp(7, now);
+                stmt.setTimestamp(8, now);
+                stmt.executeUpdate();
+            }
+
+            conn.commit();
+        }
+
+        return new TestData(regattaId, clubId, entryOneId, entryTwoId);
+    }
+
+    private record TestData(
+        UUID regattaId,
+        UUID clubId,
+        UUID entryOneId,
+        UUID entryTwoId
+    ) {
+    }
+}

--- a/pdd/design/database-schema.md
+++ b/pdd/design/database-schema.md
@@ -331,6 +331,25 @@ CREATE INDEX idx_entries_payment_status ON entries(payment_status);
 CREATE INDEX idx_entries_billing_club ON entries(billing_club_id);
 ```
 
+### club_payment_statuses table
+```sql
+CREATE TABLE club_payment_statuses (
+    regatta_id UUID NOT NULL REFERENCES regattas(id) ON DELETE CASCADE,
+    club_id UUID NOT NULL REFERENCES clubs(id) ON DELETE CASCADE,
+    payment_status VARCHAR(50) NOT NULL DEFAULT 'unpaid',
+    billable_entry_count INTEGER NOT NULL DEFAULT 0,
+    paid_entry_count INTEGER NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (regatta_id, club_id),
+    CHECK (payment_status IN ('unpaid', 'paid')),
+    CHECK (billable_entry_count >= 0),
+    CHECK (paid_entry_count >= 0),
+    CHECK (paid_entry_count <= billable_entry_count)
+);
+
+CREATE INDEX idx_club_payment_statuses_status ON club_payment_statuses(payment_status);
+```
+
 ### investigations table
 ```sql
 CREATE TABLE investigations (

--- a/pdd/design/openapi-v0.1.yaml
+++ b/pdd/design/openapi-v0.1.yaml
@@ -1479,6 +1479,82 @@ paths:
               schema:
                 $ref: "#/components/schemas/entry_billing_details"
 
+  /api/v1/regattas/{regatta_id}/entries/{entry_id}/payment_status:
+    get:
+      tags: [Finance]
+      summary: Get payment status for entry
+      security:
+        - StaffProxyAuth: []
+      parameters:
+        - $ref: "#/components/parameters/regatta_id"
+        - $ref: "#/components/parameters/entry_id"
+      responses:
+        "200":
+          description: Entry payment status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/entry_billing_details"
+    put:
+      tags: [Finance]
+      summary: Update payment status for entry
+      security:
+        - StaffProxyAuth: []
+      parameters:
+        - $ref: "#/components/parameters/regatta_id"
+        - $ref: "#/components/parameters/entry_id"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/payment_status_update_request"
+      responses:
+        "200":
+          description: Entry payment status updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/entry_billing_details"
+
+  /api/v1/regattas/{regatta_id}/clubs/{club_id}/payment_status:
+    get:
+      tags: [Finance]
+      summary: Get derived payment status for club
+      security:
+        - StaffProxyAuth: []
+      parameters:
+        - $ref: "#/components/parameters/regatta_id"
+        - $ref: "#/components/parameters/club_id"
+      responses:
+        "200":
+          description: Club payment status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/club_payment_status"
+    put:
+      tags: [Finance]
+      summary: Update payment status for all billable entries of club
+      security:
+        - StaffProxyAuth: []
+      parameters:
+        - $ref: "#/components/parameters/regatta_id"
+        - $ref: "#/components/parameters/club_id"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/payment_status_update_request"
+      responses:
+        "200":
+          description: Club payment status updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/club_payment_status"
+
   /api/v1/regattas/{regatta_id}/payments/mark_bulk:
     post:
       tags: [Finance]
@@ -3492,6 +3568,23 @@ components:
           items: { type: string, format: uuid }
         payment_status: { type: string, enum: [unpaid, paid] }
         payment_reference: { type: string }
+
+    payment_status_update_request:
+      type: object
+      required: [payment_status]
+      properties:
+        payment_status: { type: string, enum: [unpaid, paid] }
+        payment_reference: { type: string }
+
+    club_payment_status:
+      type: object
+      required: [regatta_id, club_id, payment_status, billable_entry_count, paid_entry_count]
+      properties:
+        regatta_id: { type: string, format: uuid }
+        club_id: { type: string, format: uuid }
+        payment_status: { type: string, enum: [unpaid, paid] }
+        billable_entry_count: { type: integer, minimum: 0 }
+        paid_entry_count: { type: integer, minimum: 0 }
 
     operator_token:
       type: object

--- a/pdd/implementation/bc08-finance-and-payments.md
+++ b/pdd/implementation/bc08-finance-and-payments.md
@@ -8,6 +8,12 @@ Payment-status operations for entries and clubs.
 - Implement payment status management per club.
 - Implement bulk mark paid/unpaid operations for staff workflows.
 
+## API Surface (v0.1)
+- `GET /api/v1/regattas/{regatta_id}/entries/{entry_id}/payment_status`
+- `PUT /api/v1/regattas/{regatta_id}/entries/{entry_id}/payment_status`
+- `GET /api/v1/regattas/{regatta_id}/clubs/{club_id}/payment_status`
+- `PUT /api/v1/regattas/{regatta_id}/clubs/{club_id}/payment_status`
+
 ## Non-Functional Features to Implement
 - Enforce role-based access for financial operations.
 - Preserve auditable history for payment-status changes.


### PR DESCRIPTION
## Summary
- implement BC08-001 finance payment domain/events for entry and club payment status updates
- add single-item API endpoints for entry and club payment status query/update with role-based mutation guards
- add finance projection handler and club payment status read-model table migration (PostgreSQL + H2)
- add unit and integration tests for transition rules, role-based endpoint behavior, and audit-event persistence
- update PDD docs and OpenAPI contract for new payment status endpoints and club payment projection model

## Why
Finance workflows in v0.1 need auditable paid/unpaid operations on entries and clubs with explicit authorization boundaries.

## Verification
- ./mvnw test (apps/backend)
- ./mvnw -Dtest=PaymentStatusResourceIT test (apps/backend)

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added payment status APIs to query and update payment information for entries and clubs within a regatta
  * Implemented automatic tracking of payment changes with audit details (actor, timestamp, payment reference)
  * Enabled automatic computation of club payment status based on linked entry payments
  * Added role-based access control for payment status mutations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->